### PR TITLE
Use zstyle for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,20 @@ completion
 
 Enables and configures smart and extensive tab completion.
 
-Completions are sourced from [zsh-completions](https://github.com/zsh-users/zsh-completions).
+Completions are sourced from
+[zsh-completions](https://github.com/zsh-users/zsh-completions).
+
+Settings
+--------
+
+By default, the configuration is dumped to `${ZDOTDIR:-${HOME}}/.zcompdump`.
+This file is produced to speed up the completion initialization. The file path
+can be customized with the following zstyle:
+
+    zstyle ':zim:completion' dumpfile '/path/to/.zcompdump-custom'
 
 Contributing
 ------------
 
-Command completions should be submitted [upstream to zsh-completions](https://github.com/zsh-users/zsh-completions).
+Command completions should be submitted [upstream to
+zsh-completions](https://github.com/zsh-users/zsh-completions).

--- a/init.zsh
+++ b/init.zsh
@@ -16,7 +16,9 @@ fi
 fpath=(${0:h}/external/src ${fpath})
 
 # load and initialize the completion system
-autoload -Uz compinit && compinit -C -d "${ZDOTDIR:-${HOME}}/${zcompdump_file:-.zcompdump}"
+local dumpfile
+zstyle -s ':zim:completion' dumpfile 'dumpfile' || dumpfile="${ZDOTDIR:-${HOME}}/.zcompdump"
+autoload -Uz compinit && compinit -C -d ${dumpfile}
 
 # set any compdefs
 source ${0:h}/compdefs.zsh


### PR DESCRIPTION
instead of "global" environment variables.

From the "(z)style" glossary entry of From Bash To The Z Shell:

> `style`
>
> In `zsh`, the style mechanism is a flexible way of configuring shell add-ons that use functions, such as the completion system and editor widgets. Unlike variables they can be different in different contexts and unlike shell options they can take values. The mechanism is based on the command style.