### PR TITLE
Case sensitive(ish) tab complete

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -52,7 +52,7 @@ zstyle ':completion:*:warnings' format '%F{red}-- no matches found --%f'
 zstyle ':completion:*' format '%F{yellow}-- %d --%f'
 zstyle ':completion:*' group-name ''
 zstyle ':completion:*' verbose yes
-zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' '+r:|?=**'
+zstyle ':completion:*' matcher-list '' 'm:{a-zA-Z}={A-Za-z}' '+r:|?=**'
 
 # directories
 if (( ! ${+LS_COLORS} )); then


### PR DESCRIPTION
I noticed that if I have a directory like (Directory, file.txt, FilteredFile.txt), and I hit `F<tab>`, I get a choice between file.txt and FilteredFile.txt. Given I started capitalized, I expected a direct complete rather than a choice. Turns out, [a small addition can fix this](https://stackoverflow.com/a/24237590/1610388).

Here, `F<tab>` will give me the capital file,` f<tab>` will give me the lowercase file, and even `d<tab>` will give me Directory, so I don't have to be all that careful with this option on.