### PR TITLE
Read ssh hosts from config.d/*

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -89,7 +89,9 @@ zstyle ':completion:*:history-words' menu yes
 zstyle ':completion:*:(rm|kill|diff):*' ignore-line other
 zstyle ':completion:*:rm:*' file-patterns '*:all-files'
 
-# If the _my_hosts function is defined, it will be called to add the ssh hosts
-# completion, otherwise _ssh_hosts will fall through and read the ~/.ssh/config
-zstyle -e ':completion:*:*:ssh:*:my-accounts' users-hosts \
-  '[[ -f ${HOME}/.ssh/config && ${key} == hosts ]] && key=my_hosts reply=()'
+# read hosts from /etc/{hosts,ssh/known_hosts} and ~/.ssh/{config,config.d/*}
+zstyle -e ':completion:*:hosts' hosts 'reply=(
+  ${=${=${=${${(f)"$(cat {/etc/ssh/ssh_,~/.ssh/}known_hosts(|2)(N) 2> /dev/null)"}%%[#| ]*}//\]:[0-9]*/ }//,/ }//\[/ }
+  ${=${(f)"$(cat /etc/hosts(|)(N) <<(ypcat hosts 2> /dev/null))"}%%(\#${_etc_host_ignores:+|${(j:|:)~_etc_host_ignores}})*}
+  ${=${${${${(@M)${(f)"$(cat ~/.ssh/config ~/.ssh/config.d/* 2> /dev/null)"}:#Host *}#Host }:#*\**}:#*\?*}}
+)' 

--- a/init.zsh
+++ b/init.zsh
@@ -15,7 +15,16 @@ fi
 # load and initialize the completion system
 local zdumpfile
 zstyle -s ':zim:completion' dumpfile 'zdumpfile' || zdumpfile="${ZDOTDIR:-${HOME}}/.zcompdump"
-autoload -Uz compinit && compinit -C -d ${zdumpfile}
+autoload -Uz compinit 
+# with a cache time of 20 hours, so it should almost always regenerate the first time a
+# shell is opened each day
+local zdumpfile_cache
+zdumpfile_cache=($zdumpfile(Nmh-20))
+if (( $#zdumpfile_cache )); then
+  compinit -i -C -d ${zdumpfile}
+else
+  compinit -i -d ${zdumpfile}
+fi
 
 
 #


### PR DESCRIPTION
Because I "Include config.d/*" on my .ssh/config file. Code was taken from prezto

Also omit checking for new functions for 20h on compinit, basically we check once a day. Code also taken front prezto but may need review. I ran zprof and saw compinit was the top one. Startup time drop from .06s to .04s.