### PR TITLE
Cache compinit for 20h

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -15,7 +15,14 @@ fi
 # load and initialize the completion system
 local zdumpfile
 zstyle -s ':zim:completion' dumpfile 'zdumpfile' || zdumpfile="${ZDOTDIR:-${HOME}}/.zcompdump"
-autoload -Uz compinit && compinit -C -d ${zdumpfile}
+autoload -Uz compinit
+# with a cache time of 20 hours, so it should almost always regenerate the first time a
+# shell is opened each day
+if [[ -n $zdumpfile(#qN.mh+20) ]]; then
+  compinit -d ${zdumpfile}
+else
+  compinit -d ${zdumpfile} -C # only create one if it doesn't exits
+fi
 
 
 #


### PR DESCRIPTION
Omit checking for new functions during 20h, see http://zsh.sourceforge.net/Doc/Release/Completion-System.html

I get a speed bump from 0.06s to 0.04s on zsh startup.

Don't know how this interacts with zimfw compile (we compile zcompdump).Code was taken from prezto/omz
