### PR TITLE
Remove setopt PATH_DIRS

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2015-2016 Matt Hamilton and contributors
-Copyright (c) 2016-2020 Eric Nielsen, Matt Hamilton and contributors
+Copyright (c) 2016-2021 Eric Nielsen, Matt Hamilton and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Zsh options
 -----------
 
   * `ALWAYS_TO_END` moves cursor to end of word if a full completion is inserted.
-  * `PATH_DIRS` performs path search even on command names with slashes in them.
   * `NO_CASE_GLOB` makes globbing case insensitive.
   * `NO_LIST_BEEP` doesn't beep on ambiguous completions.
 

--- a/init.zsh
+++ b/init.zsh
@@ -15,9 +15,6 @@
   # Move cursor to end of word if a full completion is inserted.
   setopt ALWAYS_TO_END
 
-  # Perform path search even on command names with slashes in them.
-  setopt PATH_DIRS
-
   # Make globbing case insensitive.
   setopt NO_CASE_GLOB
 


### PR DESCRIPTION
I see no use for [`setopt PATH_DIRS`](http://zsh.sourceforge.net/Doc/Release/Options.html#index-PATHDIRS). @Eriner, what do you think about having this removed?