### PR TITLE
Check for compdump change with dat file

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -22,11 +22,11 @@
     sysread -s ${#znew_dat} zold_dat <${zdumpfile}.dat
     [[ ${zold_dat} == ${znew_dat} ]]; zdump_dat=${?}
   fi
-  if (( zdump_dat )) command rm -f ${zdumpfile}
+  if (( zdump_dat )) command rm -f ${zdumpfile}(|.dat|.zwc(|.old))(N)
 
   autoload -Uz compinit && compinit -C -d ${zdumpfile}
 
-  if [[ ${zdump_dat} -ne 0 || ! ${zdumpfile}.dat -nt ${zdumpfile} ]]; then
+  if [[ ! ${zdumpfile}.dat -nt ${zdumpfile} ]]; then
     >! ${zdumpfile}.dat <<<${znew_dat}
   fi
   # Compile the completion dumpfile; significant speedup


### PR DESCRIPTION
containing more information, based on the data used by zsh4humans by @romkatv. The cost of checking that during startup was not significant when measured with the [zsh-branch](https://github.com/zimfw/zsh-framework-benchmark/tree/zim-branch) of zsh-framework-benchmark in the GitHub Action machine. The benefit is the end of worries about the compdump file being out-of-date.