### PR TITLE
Fix glob used for checking if dat file is up-to-date

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -9,6 +9,15 @@
   zstyle -s ':zim:glob' case-sensitivity glob_case_sensitivity || glob_case_sensitivity=insensitive
   zstyle -s ':zim:completion' case-sensitivity completion_case_sensitivity || completion_case_sensitivity=insensitive
 
+  # Glob expressions in this script require EXTENDED_GLOB option.
+  # Set it if it wasn't set and record previous state, so we
+  # can restore it later.
+  local -i extendedglob=1
+  if [[ ! -o EXTENDED_GLOB ]]; then
+    extendedglob=0
+    setopt EXTENDED_GLOB
+  fi
+
   # Check if dumpfile is up-to-date by comparing the full path and
   # last modification time of all the completion functions in fpath.
   local -i zdump_dat=1
@@ -32,6 +41,10 @@
   fi
   # Compile the completion dumpfile; significant speedup
   if [[ ! ${zdumpfile}.zwc -nt ${zdumpfile} ]] zcompile ${zdumpfile}
+
+  if (( ! extendedglob )); then
+    unsetopt EXTENDED_GLOB
+  fi
 
   #
   # Zsh options


### PR DESCRIPTION
Glob used for listing completion functions in fpath requires EXTENDED_GLOB option to be set. If it isn't set, array of completion functions will always be empty and dat file will always be considered up-to-date.

I added logic for setting EXTENDED_GLOB option and restoring it to previous state after completion is initialized.

Possibly fixes #18, but I'm not sure since that issue didn't include enough information.