### PR TITLE
Show warning on additional compinit calls

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -7,7 +7,7 @@ if [[ ${TERM} == dumb ]]; then
 fi
 
 if (( ${+_comps} )); then
-  print -u2 'warning: completion was already initialized before completion module. Look out for compinit calls in other scripts sourced during shell startup. Will call compinit again.'
+  print -u2 'warning: completion was already initialized before completion module. Will call compinit again. See https://github.com/zimfw/zimfw/wiki/Troubleshooting#completion-is-not-working'
 fi
 
 () {

--- a/init.zsh
+++ b/init.zsh
@@ -6,6 +6,10 @@ if [[ ${TERM} == dumb ]]; then
   return 1
 fi
 
+if (( ${+_comps} )); then
+  print -u2 'warning: completion was already initialized before completion module. Look out for compinit calls in other scripts sourced during shell startup. Will call compinit again.'
+fi
+
 () {
   builtin emulate -L zsh -o EXTENDED_GLOB
 
@@ -37,6 +41,10 @@ fi
   if [[ ! ${zdumpfile}.zwc -nt ${zdumpfile} ]] zcompile ${zdumpfile}
 }
 
+functions[compinit]=$'print -u2 \'warning: compinit being called again after completion module at \'${funcfiletrace[1]}
+'${functions[compinit]}
+
+#
 #
 # Zsh options
 #


### PR DESCRIPTION
It even shows the script where the additional call is happening when it's after the completion module. Doing the same for a call before the completion module would be more tricky and involve adding some code in ~/.zshenv (or more ideally /etc/zshenv) for the debugging purpose.

- [X] I've followed Zim's [code style guidelines](https://github.com/zimfw/zimfw/wiki/Code-Style-Guide).
