### PR TITLE
fix: scope LC_ALL=C to anonymous function to prevent ZLE multibyte corruption

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -15,11 +15,11 @@ fi
 
   # Check if dumpfile is up-to-date by comparing the full path and
   # last modification time of all the completion functions in fpath.
-  local zdumpfile zold_dat
+  local zdumpfile zold_dat LC_ALL=C
   local -a zmtimes
   local -i zdump_dat=1
   zstyle -s ':zim:completion' dumpfile 'zdumpfile' || zdumpfile=${ZDOTDIR:-${HOME}}/.zcompdump
-  LC_ALL=C local -r zcomps=(${^fpath}/^([^_]*|*~|*.zwc)(N))
+  local -r zcomps=(${^fpath}/^([^_]*|*~|*.zwc)(N))
   if (( ${#zcomps} )); then
     zmodload -F zsh/stat b:zstat && zstat -A zmtimes +mtime ${zcomps} || return 1
   fi


### PR DESCRIPTION
# fix: scope LC_ALL=C to anonymous function to prevent ZLE multibyte corruption

## Problem

In `init.zsh`, `LC_ALL=C` was used as a command prefix on the `local` builtin:

```zsh
LC_ALL=C local -r zcomps=(${^fpath}/^([^_]*|*~|*.zwc)(N))
```

In zsh, prefixed variable assignments on **builtins** (unlike external commands) persist in the current scope after the command completes. Since `LC_ALL` was never declared `local` inside the anonymous function, the assignment leaked into the interactive shell environment after `init.zsh` was sourced.

This caused zsh's ZLE to initialize in **single-byte (C locale) mode**, breaking multibyte character handling. The symptom was that pressing TAB to complete a command (e.g. `cd<TAB>`) would corrupt the line buffer, duplicating a character (e.g. `ccd`).

## Affected terminals

The bug only manifests in terminals that do **not** inject a UTF-8 locale into the shell environment automatically:

| Terminal | Behavior | Reason |
|---|---|---|
| Apple Terminal | Affected | Does not set `LANG`/`LC_CTYPE`; relies on system locale propagation which often yields no `.UTF-8` suffix |
| IntelliJ IDEA | Affected | Embedded terminal runs inside a JVM process that strips locale variables from the child shell environment |
| iTerm2 | Unaffected | Explicitly injects `LANG=en_US.UTF-8` into every session via "Set locale variables automatically" |
| Ghostty | Unaffected | Sets locale variables automatically when spawning shells |

In unaffected terminals, the pre-existing `LANG=en_US.UTF-8` means ZLE is already initialized in multibyte mode before the leak occurs. In affected terminals, there is no prior UTF-8 locale to counteract it.

The `COMPLETE_IN_WORD` option set by this module made the issue more visible, as it involves more cursor repositioning during completion.

## Fix

Move `LC_ALL=C` into the existing `local` declaration so it is properly scoped to the anonymous function:

```zsh
local zdumpfile zold_dat LC_ALL=C
```

The glob expansion on the `zcomps` line still runs under `LC_ALL=C` (since the variable is set before it executes), preserving the intended behavior of predictable character class matching. The variable is now automatically cleaned up when the function exits.
